### PR TITLE
allow ":" or "=" inside metadata value

### DIFF
--- a/src/vtt/vtt-parser.ts
+++ b/src/vtt/vtt-parser.ts
@@ -115,8 +115,11 @@ export class VTTParser implements CaptionsParser {
   protected _parseHeader(line: string, lineCount: number) {
     if (lineCount > 1) {
       if (SETTING_SEP_RE.test(line)) {
-        const [key, value] = line.split(SETTING_SEP_RE);
-        if (key) this._metadata[key] = (value || '').replace(SPACE_RE, '');
+        // get index of first separator
+        const firstSepIndex = line.match(SETTING_SEP_RE)!.index!;
+        const key = line.substring(0, firstSepIndex).trim();
+        const value = line.substring(firstSepIndex + 1).trim();
+        this._metadata[key] = value;
       }
     } else if (line.startsWith(HEADER_MAGIC)) {
       this._block = VTTBlock.Header;

--- a/tests/vtt/header.test.ts
+++ b/tests/vtt/header.test.ts
@@ -14,9 +14,9 @@ test('BAD: should throw in strict mode if header is missing', async () => {
   ).rejects.toThrowError();
 });
 
-test('GOOD: parse header metadata', async () => {
+test('GOOD: parse header metadata with : and =', async () => {
   const { errors, metadata, cues } = await parseText(
-    ['WEBVTT', 'Kind: Language', 'Language:en-US'].join('\n'),
+    ['WEBVTT', 'Kind: Language', 'Language= en-US'].join('\n'),
   );
 
   expect(errors).toHaveLength(0);
@@ -28,4 +28,50 @@ test('GOOD: parse header metadata', async () => {
       "Language": "en-US",
     }
   `);
+});
+
+test('GOOD: parse header metadata with proper trimming', async () => {
+  const { errors, metadata, cues } = await parseText(
+    ['WEBVTT', 'Message:Hello World! ', ' My Property : Value '].join('\n'),
+  );
+
+  expect(errors).toHaveLength(0);
+  expect(cues).toHaveLength(0);
+
+  expect(metadata).toStrictEqual({
+    'Message': 'Hello World!',
+    'My Property': 'Value',
+  });
+});
+
+test('GOOD: parse header metadata with value containing = or :', async () => {
+  const { errors, metadata, cues } = await parseText(
+    ['WEBVTT', 'Key1: Value with = sign', 'Key2: Value with : colon'].join('\n'),
+  );
+
+  expect(errors).toHaveLength(0);
+  expect(cues).toHaveLength(0);
+
+  expect(metadata).toStrictEqual({
+    "Key1": "Value with = sign",
+    "Key2": "Value with : colon",
+  });
+});
+
+test('GOOD: parse header metadata with JSON and "=" in value', async () => {
+  const { errors, metadata, cues } = await parseText(
+    ['WEBVTT', 
+     'X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:0',
+     'Json: {"a": 1, "b": 2}',
+     'Eval: 1 + 1 = 2'].join('\n'),
+  );
+
+  expect(errors).toHaveLength(0);
+  expect(cues).toHaveLength(0);
+
+  expect(metadata).toStrictEqual({
+    "X-TIMESTAMP-MAP": "LOCAL:00:00:00.000,MPEGTS:0",
+    "Json": '{"a": 1, "b": 2}',
+    "Eval": "1 + 1 = 2",
+  });
 });


### PR DESCRIPTION
- fix issue where metadata value get cut off when containing ":" or "="
- fix trimming logic, for example, "Message:Hello World" would parsed as `{ Message: "HelloWorld"}` whereas "Message: Hello World" being `{ Message: "Hello World"}`. 

more cases included in tests